### PR TITLE
Provide compatibility with TypeScript 5.0

### DIFF
--- a/chai.d.ts
+++ b/chai.d.ts
@@ -1,3 +1,11 @@
-import chai from "chai";
-
-export = chai;
+export {
+  assert,
+  expect,
+  should,
+  use,
+  util,
+  config,
+  Assertion,
+  AssertionError,
+  version, 
+} from 'chai';


### PR DESCRIPTION
The current code errors on the `export =` statement with the message:

```
Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.ts(1203)
```